### PR TITLE
feat(start screen):Add loading animation

### DIFF
--- a/game/GameAssets.js
+++ b/game/GameAssets.js
@@ -53,6 +53,15 @@ class GameAssets {
 
         retroFont.load().then((loadedFont) => {
           document.fonts.add(loadedFont);
+
+          const loadingAnimationElement =
+            document.getElementById("loading-animation");
+
+          loadingAnimationElement.setAttribute(
+            "class",
+            "hide-loading-animation"
+          );
+
           startScreen.load();
         });
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <title>One Friday in Berlin</title>
   </head>
   <body>
+    <div id="loading-animation" class="loading-animation">Loading...</div>
     <canvas id="canvas" width="700px" height="550px"></canvas>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: "retroFont";
+  src: url("./fonts/PressStart2P-Regular.ttf") format("truetype");
+}
+
 html {
   margin: 0;
   padding: 0;
@@ -19,4 +24,27 @@ body {
 
 canvas {
   border: 5px solid black;
+  background-color: #000;
+}
+
+.hide-loading-animation {
+  display: none;
+}
+
+.loading-animation {
+  position: fixed;
+  margin-left: 40px;
+
+  color: #fff;
+  font-weight: bold;
+  font-family: monospace;
+  font-family: "retroFont", Courier, monospace;
+  font-size: 30px;
+  clip-path: inset(0 3ch 0 0);
+  animation: loader 1s steps(4) infinite;
+}
+@keyframes loader {
+  to {
+    clip-path: inset(0 -1ch 0 0);
+  }
 }


### PR DESCRIPTION
- Add a loading animation to the start screen that shows while the images are pre-loading. Remove the animation once all images have loaded.